### PR TITLE
CPU-only inference

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,7 +100,7 @@ pub fn error_correction<T, U, V>(
     cluster_path: &str,
     threads: usize,
     window_size: u32,
-    devices: Vec<usize>,
+    devices: Vec<String>,
     batch_size: usize,
     aln_mode: AlnMode<V>,
 ) where
@@ -160,7 +160,7 @@ pub fn error_correction<T, U, V>(
             s.spawn(move || {
                 inference_worker(
                     model_path,
-                    tch::Device::Cuda(device),
+                    if device == "cpu" { tch::Device::Cpu } else { tch::Device::Cuda(device.parse::<usize>().unwrap()) },
                     infer_recv,
                     cons_sender,
                 )

--- a/src/main.rs
+++ b/src/main.rs
@@ -87,9 +87,9 @@ struct InferenceArgs {
         short = 'd',
         value_delimiter = ',',
         default_value = "0",
-        help = "List of cuda devices in format d0,d1... (e.g 0,1,3) (default 0)"
+        help = "List of cuda devices in format d0,d1... (e.g 0,1,3), or cpu to use CPU (default 0)"
     )]
-    devices: Vec<usize>,
+    devices: Vec<String>,
 
     #[arg(
         short = 'b',


### PR DESCRIPTION
Adds a very simple CPU-only mode for inference for servers without GPUs. Modifies the `-d` parameter to allow value `cpu` which uses a CPU instead of a GPU device. Multiple threads by specifying the number of cpus in unary, eg. `-d cpu,cpu,cpu,cpu` uses four threads. Suggest `-t 1` and also low batch size.

Much slower than GPU inference. Using 32 threads (with `-t 1 -b 4`) on an 18x coverage whole human genome ultralong R10.4.1 dataset took 3 days 7 hours and peak 116Gb RAM.