### PR TITLE
v0.1.1: Haplotype-aware sorting, libtorch 2.4.0, and infrastructure updates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "herro"
-version = "0.2.0"
+version = "0.1.1"
 authors = ["Dominik Stanojevic"]
 edition = "2021"
 description = "HERRO is a haplotype-aware, deep-learning tool for error correction of Nanopore ultralong (UL) reads."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ indicatif = "~0.17.2"
 ordered-float = "~4.2.0"
 ndarray = "~0.15.6"
 npyz = { version = "~0.8.1", features = ["derive"] }
-tch = "0.13.0"
+tch = "~0.17.0"
 crossbeam-channel = "~0.5.8"
 rustc-hash = "~1.1.0"
 glob = "~0.3.1"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage: devel
-FROM nvidia/cuda:11.7.1-cudnn8-runtime-ubuntu22.04 as devel
+FROM nvidia/cuda:12.4.1-cudnn-runtime-ubuntu22.04 as devel
 
 # Install essential packages
 RUN apt-get update \
@@ -15,7 +15,7 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y \
     && export PATH="/root/.cargo/bin:${PATH}"
 
 # Get libtorch
-RUN wget -q -O libtorch.zip https://download.pytorch.org/libtorch/cu117/libtorch-cxx11-abi-shared-with-deps-2.0.1%2Bcu117.zip \
+RUN wget -q -O libtorch.zip https://download.pytorch.org/libtorch/cu124/libtorch-cxx11-abi-shared-with-deps-2.4.0%2Bcu124.zip \
     && unzip -q libtorch.zip && rm libtorch.zip \
     && export LIBTORCH=/libtorch \
     && export LD_LIBRARY_PATH=${LIBTORCH}/lib:$LD_LIBRARY_PATH
@@ -31,7 +31,7 @@ RUN export LIBTORCH=/libtorch \
     && RUSTFLAGS="-Ctarget-cpu=native" cargo build -q --release
 
 # Stage: final
-FROM nvidia/cuda:11.7.1-cudnn8-runtime-ubuntu22.04 as final
+FROM nvidia/cuda:12.4.1-cudnn-runtime-ubuntu22.04 as final
 
 # Copy files from the previous stage
 COPY --from=devel /minimap2/minimap2 /bin/minimap2
@@ -49,5 +49,5 @@ ENV LD_LIBRARY_PATH=${LIBTORCH}/lib:$LD_LIBRARY_PATH
 
 # Labels
 LABEL Author="Dominik Stanojevic"
-LABEL Version="v0.0.1"
+LABEL Version="v0.1.1"
 LABEL Name="herro"

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ HERRO (Haplotype-aware ERRor cOrrection)  is a highly accurate, haplotype-aware,
 
 ### Compile from source
 
-- [libtorch 2.0.*](https://download.pytorch.org/libtorch/cu117/libtorch-cxx11-abi-shared-with-deps-2.0.1%2Bcu117.zip)
+- [libtorch 2.4.*](https://download.pytorch.org/libtorch/cu124/libtorch-cxx11-abi-shared-with-deps-2.4.0%2Bcu124.zip)
 - [rustup](https://rustup.rs/)
 
 

--- a/herro-singularity.def
+++ b/herro-singularity.def
@@ -1,5 +1,5 @@
 Bootstrap: docker
-From: nvidia/cuda:11.7.1-cudnn8-runtime-ubuntu22.04
+From: nvidia/cuda:12.4.1-cudnn-runtime-ubuntu22.04
 Stage: devel
 
 %files
@@ -19,7 +19,7 @@ Stage: devel
     export PATH="/root/.cargo/bin:${PATH}"
 
     # Get libtorch
-    wget -q -O libtorch.zip https://download.pytorch.org/libtorch/cu117/libtorch-cxx11-abi-shared-with-deps-2.0.1%2Bcu117.zip
+    wget -q -O libtorch.zip https://download.pytorch.org/libtorch/cu124/libtorch-cxx11-abi-shared-with-deps-2.4.0%2Bcu124.zip
     unzip -q libtorch.zip && rm libtorch.zip
     export LIBTORCH=/libtorch
     export LD_LIBRARY_PATH=${LIBTORCH}/lib:$LD_LIBRARY_PATH
@@ -30,7 +30,7 @@ Stage: devel
 
 
 Bootstrap: docker
-From: nvidia/cuda:11.7.1-cudnn8-runtime-ubuntu22.04
+From: nvidia/cuda:12.4.1-cudnn-runtime-ubuntu22.04
 Stage: final
 
 %files from devel
@@ -52,5 +52,5 @@ Stage: final
 
 %labels
     Author Dominik Stanojevic
-    Version v0.2.0
+    Version v0.1.1
     Name herro

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -101,13 +101,6 @@ fn consensus(data: ConsensusData, counts: &mut [u8], read: &HAECRecord) -> Optio
     };
 
     for (wid, window) in data[wid_st..wid_en].iter().enumerate() {
-        /*if window.n_alns < 2 {
-            let start = wid * window_size;
-            let end = ((wid + 1) * window_size).min(uncorrected.len());
-
-            corrected.extend(&uncorrected[start..end]);
-            continue;
-        }*/
         if window.n_alns < 2 {
             if corrected.len() > 0 {
                 corrected_seqs.push(corrected);
@@ -117,8 +110,6 @@ fn consensus(data: ConsensusData, counts: &mut [u8], read: &HAECRecord) -> Optio
             continue;
         }
 
-        // Don't analyze empty rows: LxR -> LxN
-        //let n_rows = (window.n_alns + 1).min(TOP_K + 1);
         let n_rows = window.n_alns + 1;
         let bases = window.bases.slice(s![.., ..n_rows as usize]);
         let maybe_info = match window.supported.len() {

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -1,4 +1,5 @@
 use ndarray::Array2;
+use ordered_float::OrderedFloat;
 
 use std::{cmp::Reverse, collections::BinaryHeap};
 
@@ -11,6 +12,7 @@ use rustc_hash::FxHashMap as HashMap;
 
 use crate::features::SupportedPos;
 
+use crate::haec_io::HAECRecord;
 use crate::inference::BASES_MAP;
 
 const BASES_UPPER: [u8; 10] = [b'A', b'C', b'G', b'T', b'*', b'A', b'C', b'G', b'T', b'*'];
@@ -27,7 +29,7 @@ pub(crate) struct ConsensusWindow {
     pub(crate) indices: Vec<usize>,
     pub(crate) supported: Vec<SupportedPos>,
     pub(crate) info_logits: Option<Vec<f32>>,
-    pub(crate) bases_logits: Option<Vec<u8>>,
+    pub(crate) bases_logits: Option<Vec<Vec<f32>>>,
 }
 
 impl ConsensusWindow {
@@ -41,7 +43,7 @@ impl ConsensusWindow {
         indices: Vec<usize>,
         supported: Vec<SupportedPos>,
         info_logits: Option<Vec<f32>>,
-        bases_logits: Option<Vec<u8>>,
+        bases_logits: Option<Vec<Vec<f32>>>,
     ) -> Self {
         Self {
             rid,
@@ -81,7 +83,7 @@ where
     heap.into_sorted_vec().into_iter().map(|r| r.0).collect()
 }
 
-fn consensus(data: ConsensusData, counts: &mut [u8]) -> Option<Vec<Vec<u8>>> {
+fn consensus(data: ConsensusData, counts: &mut [u8], read: &HAECRecord) -> Option<Vec<Vec<u8>>> {
     let mut corrected_seqs = Vec::new();
     let mut corrected: Vec<u8> = Vec::new();
 
@@ -98,7 +100,7 @@ fn consensus(data: ConsensusData, counts: &mut [u8]) -> Option<Vec<Vec<u8>>> {
         MinMax(st, en) => (st, en + 1),
     };
 
-    for window in data[wid_st..wid_en].iter() {
+    for (wid, window) in data[wid_st..wid_en].iter().enumerate() {
         /*if window.n_alns < 2 {
             let start = wid * window_size;
             let end = ((wid + 1) * window_size).min(uncorrected.len());
@@ -126,7 +128,7 @@ fn consensus(data: ConsensusData, counts: &mut [u8]) -> Option<Vec<Vec<u8>>> {
                 .iter()
                 .zip(window.info_logits.as_ref().unwrap().iter())
                 .zip(window.bases_logits.as_ref().unwrap().iter())
-                .map(|((supp, il), bl)| (*supp, (*il, *bl)))
+                .map(|((supp, il), bl)| (*supp, (*il, bl)))
                 .collect(),
         };
 
@@ -140,7 +142,13 @@ fn consensus(data: ConsensusData, counts: &mut [u8]) -> Option<Vec<Vec<u8>>> {
             }
 
             if let Some((_, b)) = maybe_info.get(&SupportedPos::new(pos as u16, ins)) {
-                let base = match *b {
+                let argmax = b
+                    .iter()
+                    .enumerate()
+                    .max_by_key(|(_, &v)| OrderedFloat(v))
+                    .unwrap()
+                    .0 as u8;
+                let base = match argmax {
                     0 => b'A',
                     1 => b'C',
                     2 => b'G',
@@ -159,7 +167,7 @@ fn consensus(data: ConsensusData, counts: &mut [u8]) -> Option<Vec<Vec<u8>>> {
                 }*/
 
                 /*println!(
-                    "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
+                    "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{:?}\t{}",
                     std::str::from_utf8(&read.id).unwrap(),
                     wid,
                     pos,
@@ -167,8 +175,10 @@ fn consensus(data: ConsensusData, counts: &mut [u8]) -> Option<Vec<Vec<u8>>> {
                     corrected_seqs.len(),
                     corrected.len(),
                     'S',
+                    b,
                     base
                 );*/
+
                 if base != b'*' {
                     corrected.push(base);
                 }
@@ -199,7 +209,7 @@ fn consensus(data: ConsensusData, counts: &mut [u8]) -> Option<Vec<Vec<u8>>> {
                 };
 
                 /*println!(
-                    "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
+                    "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{:?}\t{}",
                     std::str::from_utf8(&read.id).unwrap(),
                     wid,
                     pos,
@@ -207,8 +217,10 @@ fn consensus(data: ConsensusData, counts: &mut [u8]) -> Option<Vec<Vec<u8>>> {
                     corrected_seqs.len(),
                     corrected.len(),
                     "N",
+                    counts,
                     base,
                 );*/
+
                 if base != b'*' {
                     corrected.push(base);
                 }
@@ -224,6 +236,7 @@ fn consensus(data: ConsensusData, counts: &mut [u8]) -> Option<Vec<Vec<u8>>> {
 }
 
 pub(crate) fn consensus_worker(
+    reads: &[HAECRecord],
     receiver: Receiver<ConsensusData>,
     sender: Sender<(usize, Vec<Vec<u8>>)>,
 ) {
@@ -246,7 +259,7 @@ pub(crate) fn consensus_worker(
                 let mut windows = consensus_data.remove(&rid).unwrap();
                 windows.sort_by_key(|cw| cw.wid);
 
-                let seq = consensus(windows, &mut counts);
+                let seq = consensus(windows, &mut counts, &reads[rid as usize]);
 
                 if let Some(s) = seq {
                     sender.send((rid as usize, s)).unwrap();

--- a/src/features.rs
+++ b/src/features.rs
@@ -323,7 +323,7 @@ fn get_features_for_window(
 
 fn overlap_window_filter(cigar: &[u8]) -> bool {
     let long_indel = CigarIter::new(cigar).any(|(op, _)| match op {
-        CigarOp::Insertion(l) | CigarOp::Deletion(l) if l >= 30 => true,
+        CigarOp::Insertion(l) | CigarOp::Deletion(l) if l > 50 => true,
         _ => false,
     });
 

--- a/src/features.rs
+++ b/src/features.rs
@@ -151,16 +151,7 @@ fn get_features_for_ol_window(
                 )
             }
         };
-    //let mut query_iter = query_iter.skip(window.qstart as usize);
 
-    // Number of cigars for the window
-    // TODO get error when we calculate correct number for end -> (idx, 0)
-    // Works for this expression but unecessarily iterates through (idx, 0)
-    //let cigar_len = window.cigar_end_idx - window.cigar_start_idx + 1;
-    //let cigar_end = cigar.len().min((window.cigar_end_idx + 1) as usize);
-
-    // Handle cigar
-    //let cigar = cigar[window.cigar_start_idx as usize..cigar_end].iter();
     let cigar = CigarIter::new(&cigar[window.cigar_start_idx..window.cigar_end_idx]);
 
     // Get features
@@ -352,33 +343,6 @@ pub(crate) fn extract_features<'a, T: FeaturesOutput<'a>>(
     for alignment in overlaps.iter() {
         let qid = alignment.overlap.return_other_id(rid);
 
-        // TODO - Remove this if unecessary
-        /*let mut cigar = get_proper_cigar(&alignment.cigar, overlap.tid == rid, overlap.strand);
-
-        // TODO - get proper target and query
-        let (tstart, tend, qstart, qend) = if overlap.tid == rid {
-            (overlap.tstart, overlap.tend, overlap.qstart, overlap.qend)
-        } else {
-            (overlap.qstart, overlap.qend, overlap.tstart, overlap.tend)
-        };
-
-        let tlen = tend as usize - tstart as usize;
-        reads[rid as usize]
-            .seq
-            .get_subseq(tstart as usize..tend as usize, tbuf);
-
-        let qlen = qend as usize - qstart as usize;
-        if overlaps::Strand::Forward == overlap.strand {
-            reads[qid as usize]
-                .seq
-                .get_subseq(qstart as usize..qend as usize, qbuf);
-        } else {
-            reads[qid as usize]
-                .seq
-                .get_rc_subseq(qstart as usize..qend as usize, qbuf);
-        }
-        let (tshift, qshift) = fix_cigar(&mut cigar, &tbuf[..tlen], &qbuf[..qlen]); */
-
         let (tshift, qshift) = (0, 0);
 
         //Extract windows
@@ -395,10 +359,6 @@ pub(crate) fn extract_features<'a, T: FeaturesOutput<'a>>(
 
         ovlps_cigar_map.insert(qid, &alignment.cigar);
     }
-
-    // Create directory for the read
-    //let output_path = Path::new("features").join(&read.id);
-    //create_dir_all(&output_path).expect("Cannot create directory");
 
     feats_output.init(rid, &read.id);
     for i in 0..n_windows {
@@ -757,43 +717,6 @@ where
             supporeted.push(SupportedPos::new(tpos as u16, ins));
         }
     }
-
-    /*for l in 1..len + 1 {
-        if l != len && bases[[0, l]] == b'*' {
-            // Gap in target -> do not test
-            continue;
-        }
-
-        let subseq = bases.slice(s![.., start..l]);
-        counter.clear();
-        for read_subseq in subseq.axis_iter(Axis(0)) {
-            let mut hasher = FxHasher::default();
-            let result = read_subseq.iter().try_for_each(|&v| {
-                if v == b'.' {
-                    return Err(()); // No alignment position present
-                } else {
-                    hasher.write_u8(BASE_FORWARD[v as usize]);
-                    return Ok(());
-                }
-            });
-
-            if result.is_ok() {
-                // Check if alignment is really aligned
-                let entry = counter.entry(hasher.finish()).or_insert(0);
-                *entry += 1;
-            }
-        }
-
-        let n_supported = counter
-            .iter()
-            .fold(0u8, |acc, (_, &c)| if c >= 3 { acc + 1 } else { acc });
-        if n_supported >= 2 {
-            supporeted.push(tpos);
-        }
-
-        start = l;
-        tpos += 1;
-    }*/
 
     supporeted
 }

--- a/src/features.rs
+++ b/src/features.rs
@@ -1,5 +1,7 @@
 use npyz::WriterBuilder;
 use rustc_hash::FxHashMap as HashMap;
+use rustc_hash::FxHashSet as HashSet;
+use std::cmp::Reverse;
 use std::fs::{create_dir_all, File};
 use std::io::prelude::*;
 use std::io::{BufWriter, Result};
@@ -346,6 +348,7 @@ pub(crate) fn extract_features<'a, T: FeaturesOutput<'a>>(
     let mut windows = vec![Vec::new(); n_windows];
 
     let mut ovlps_cigar_map = HashMap::default();
+    let mut all_features = Vec::new();
     for alignment in overlaps.iter() {
         let qid = alignment.overlap.return_other_id(rid);
 
@@ -465,7 +468,7 @@ pub(crate) fn extract_features<'a, T: FeaturesOutput<'a>>(
             qbuf,
         );
 
-        let qids: Vec<&str> = windows[i]
+        let qids: Vec<_> = windows[i]
             .iter()
             .map(|ow| {
                 std::str::from_utf8(&reads[ow.overlap.return_other_id(rid) as usize].id).unwrap()
@@ -474,11 +477,112 @@ pub(crate) fn extract_features<'a, T: FeaturesOutput<'a>>(
 
         let supported = get_supported(&bases);
 
-        feats_output.update(
+        /*feats_output.update(
             rid,
             i as u16,
             bases,
             quals,
+            supported,
+            qids,
+            n_windows as u16,
+        );*/
+
+        all_features.push((
+            rid,
+            i as u16,
+            bases,
+            quals,
+            supported,
+            qids,
+            n_windows as u16,
+        ));
+    }
+
+    // Calculate ratios
+    let mut ratios = HashMap::default();
+    for (rid, i, bases, quals, supported, qids, n_windows) in all_features.iter() {
+        let pos_to_idx = bases
+            .slice(s![.., 0])
+            .iter()
+            .enumerate()
+            .filter(|&(_, b)| *b != b'*')
+            .map(|(i, _)| i)
+            .collect::<Vec<_>>();
+        let indices = supported
+            .iter()
+            .map(|s| pos_to_idx[s.pos as usize] + s.ins as usize)
+            .collect::<HashSet<_>>();
+
+        let tgt = bases.slice(s![.., 0]);
+
+        for (qid, row_idx) in qids.iter().zip(1..).take(TOP_K) {
+            let qry = bases.slice(s![.., row_idx]);
+
+            for (pos, (tgt_b, qry_b)) in tgt.iter().zip(qry.iter()).enumerate() {
+                if !indices.contains(&pos) {
+                    continue;
+                }
+
+                let t = (*tgt_b as char).to_ascii_uppercase();
+                let q = (*qry_b as char).to_ascii_uppercase();
+
+                if t == '*' {
+                    continue;
+                }
+
+                if q == t {
+                    ratios.entry(qid.to_string()).or_insert((0., 0.)).0 += 1.;
+                } else {
+                    ratios.entry(qid.to_string()).or_insert((0., 0.)).1 += 1.;
+                }
+            }
+        }
+    }
+
+    for (rid, i, bases, quals, supported, qids, n_windows) in all_features {
+        let mut iden = vec![OrderedFloat(f64::MAX)];
+        for &qry_rid in qids.iter().take(TOP_K) {
+            let s = ratios
+                .get(qry_rid)
+                .map_or(0., |(n, d)| n / (n + d) * f64::ln(n + d + 1.));
+
+            iden.push(OrderedFloat(s));
+        }
+
+        let mut sr = (0..iden.len()).collect::<Vec<_>>();
+        sr.sort_by_key(|&i| Reverse(iden[i]));
+
+        let mut new_bases = Vec::new();
+        let mut new_quals = Vec::new();
+
+        for &i in sr.iter() {
+            new_bases.push(bases.index_axis(Axis(1), i));
+            new_quals.push(quals.index_axis(Axis(1), i));
+        }
+        for i in sr.len()..TOP_K + 1 {
+            new_bases.push(bases.index_axis(Axis(1), i));
+            new_quals.push(quals.index_axis(Axis(1), i));
+        }
+
+        assert_eq!(new_bases.len(), TOP_K + 1);
+        assert_eq!(new_quals.len(), TOP_K + 1);
+
+        let new_bases = stack(Axis(1), &new_bases)
+            .unwrap()
+            .as_standard_layout()
+            .to_owned();
+        let new_quals = stack(Axis(1), &new_quals)
+            .unwrap()
+            .as_standard_layout()
+            .to_owned();
+
+        let qids = sr.iter().skip(1).map(|&i| qids[i - 1]).collect();
+
+        feats_output.update(
+            rid,
+            i as u16,
+            new_bases,
+            new_quals,
             supported,
             qids,
             n_windows as u16,

--- a/src/features.rs
+++ b/src/features.rs
@@ -323,7 +323,7 @@ fn get_features_for_window(
 
 fn overlap_window_filter(cigar: &[u8]) -> bool {
     let long_indel = CigarIter::new(cigar).any(|(op, _)| match op {
-        CigarOp::Insertion(l) | CigarOp::Deletion(l) if l >= 30 => true,
+        CigarOp::Insertion(l) | CigarOp::Deletion(l) if l >= 50 => true,
         _ => false,
     });
 

--- a/src/features.rs
+++ b/src/features.rs
@@ -19,7 +19,7 @@ use crate::overlaps::{Alignment, Strand};
 use crate::pbars::PBarNotification;
 use crate::windowing::{extract_windows, OverlapWindow};
 
-pub(crate) const TOP_K: usize = 30;
+pub(crate) const TOP_K_SORT: usize = 30;
 
 const BASE_LOWER: [u8; 128] = [
     255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
@@ -49,7 +49,7 @@ fn get_max_ins_for_window(
     window_length: usize,
 ) -> Vec<u16> {
     let mut max_ins = vec![0; window_length];
-    for ow in overlaps.iter().take(TOP_K) {
+    for ow in overlaps.iter() {
         let mut tpos = ow.tstart as usize - tstart;
 
         // Handle cigar
@@ -288,8 +288,8 @@ fn get_features_for_window(
     //Get features
     let length = max_ins.iter().map(|v| *v as usize).sum::<usize>() + max_ins.len();
 
-    let mut bases = Array::from_elem((length, 1 + TOP_K), b'.');
-    let mut quals = Array::from_elem((length, 1 + TOP_K), b'!');
+    let mut bases = Array::from_elem((length, 1 + overlaps.len().max(TOP_K_SORT)), b'.');
+    let mut quals = Array::from_elem((length, 1 + overlaps.len().max(TOP_K_SORT)), b'!');
 
     // First write the target
     write_target_for_window(
@@ -303,7 +303,7 @@ fn get_features_for_window(
     );
 
     // Write top-k overlaps for the window
-    overlaps.iter().take(TOP_K).enumerate().for_each(|(i, ow)| {
+    overlaps.iter().enumerate().for_each(|(i, ow)| {
         let qid = ow.overlap.return_other_id(tid);
         get_features_for_ol_window(
             bases.index_axis_mut(Axis(1), i + 1),
@@ -323,7 +323,7 @@ fn get_features_for_window(
 
 fn overlap_window_filter(cigar: &[u8]) -> bool {
     let long_indel = CigarIter::new(cigar).any(|(op, _)| match op {
-        CigarOp::Insertion(l) | CigarOp::Deletion(l) if l >= 50 => true,
+        CigarOp::Insertion(l) | CigarOp::Deletion(l) if l >= 30 => true,
         _ => false,
     });
 
@@ -515,7 +515,7 @@ pub(crate) fn extract_features<'a, T: FeaturesOutput<'a>>(
 
         let tgt = bases.slice(s![.., 0]);
 
-        for (qid, row_idx) in qids.iter().zip(1..).take(TOP_K) {
+        for (qid, row_idx) in qids.iter().zip(1..) {
             let qry = bases.slice(s![.., row_idx]);
 
             for (pos, (tgt_b, qry_b)) in tgt.iter().zip(qry.iter()).enumerate() {
@@ -541,7 +541,7 @@ pub(crate) fn extract_features<'a, T: FeaturesOutput<'a>>(
 
     for (rid, i, bases, quals, supported, qids, n_windows) in all_features {
         let mut iden = vec![OrderedFloat(f64::MAX)];
-        for &qry_rid in qids.iter().take(TOP_K) {
+        for &qry_rid in qids.iter() {
             let s = ratios
                 .get(qry_rid)
                 .map_or(0., |(n, d)| n / (n + d) * f64::ln(n + d + 1.));
@@ -555,26 +555,56 @@ pub(crate) fn extract_features<'a, T: FeaturesOutput<'a>>(
         let mut new_bases = Vec::new();
         let mut new_quals = Vec::new();
 
-        for &i in sr.iter() {
+        for &i in sr.iter().take(TOP_K_SORT + 1) {
             new_bases.push(bases.index_axis(Axis(1), i));
             new_quals.push(quals.index_axis(Axis(1), i));
         }
-        for i in sr.len()..TOP_K + 1 {
+        for i in sr.len()..TOP_K_SORT + 1 {
             new_bases.push(bases.index_axis(Axis(1), i));
             new_quals.push(quals.index_axis(Axis(1), i));
         }
 
-        assert_eq!(new_bases.len(), TOP_K + 1);
-        assert_eq!(new_quals.len(), TOP_K + 1);
+        assert_eq!(new_bases.len(), TOP_K_SORT + 1);
+        assert_eq!(new_quals.len(), TOP_K_SORT + 1);
 
-        let new_bases = stack(Axis(1), &new_bases)
-            .unwrap()
+        let new_bases = stack(Axis(1), &new_bases).unwrap();
+        let retain_idx: Vec<_> = new_bases
+            .axis_iter(Axis(0))
+            .enumerate()
+            .filter_map(|(pos, col)| {
+                let all_gap = col
+                    .iter()
+                    .filter(|&b| *b != b'.')
+                    .all(|&b| b == b'*' || b == b'#');
+                if all_gap {
+                    None
+                } else {
+                    Some(pos)
+                }
+            })
+            .collect();
+
+        let new_bases = new_bases
+            .select(Axis(0), &retain_idx)
             .as_standard_layout()
             .to_owned();
+
+        let new_quals = stack(Axis(1), &new_quals)
+            .unwrap()
+            .select(Axis(0), &retain_idx)
+            .as_standard_layout()
+            .to_owned();
+
+        let supported = get_supported(&new_bases);
+
+        /*let new_bases = stack(Axis(1), &new_bases)
+        .unwrap()
+        .as_standard_layout()
+        .to_owned();
         let new_quals = stack(Axis(1), &new_quals)
             .unwrap()
             .as_standard_layout()
-            .to_owned();
+            .to_owned();*/
 
         let qids = sr.iter().skip(1).map(|&i| qids[i - 1]).collect();
 
@@ -692,9 +722,7 @@ fn get_supported<S>(bases: &ArrayBase<S, Ix2>) -> Vec<SupportedPos>
 where
     S: Data<Elem = u8>,
 {
-    // bases -> [R, L]
-
-    let mut counter: HashMap<u8, u8> = HashMap::default();
+    let mut counter: HashMap<u8, usize> = HashMap::default();
     counter.insert(b'A', 0);
     counter.insert(b'C', 0);
     counter.insert(b'G', 0);
@@ -721,9 +749,10 @@ where
             *counter.get_mut(&BASE_FORWARD[b as usize]).unwrap() += 1;
         });
 
+        let thresh = (bases.len_of(Axis(1)) as f64 * 0.1) as usize;
         let n_supported = counter
             .iter()
-            .fold(0u8, |acc, (_, &c)| if c >= 3 { acc + 1 } else { acc });
+            .fold(0u8, |acc, (_, &c)| if c >= thresh { acc + 1 } else { acc });
         if n_supported >= 2 {
             supporeted.push(SupportedPos::new(tpos as u16, ins));
         }
@@ -922,7 +951,7 @@ impl<'a> FeaturesOutput<'a> for InferenceOutput {
         self.features.push(WindowExample::new(
             rid,
             wid,
-            ids.len().min(TOP_K) as u8,
+            ids.len().min(TOP_K_SORT) as u8,
             bases,
             quals,
             supported,

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -131,21 +131,6 @@ fn collate<'a>(batch: &[(u32, &ConsensusWindow)]) -> InferenceBatch {
         bases.i((idx as i64, ..l as i64, ..)).copy_(&bt);
         quals.i((idx as i64, ..l as i64, ..)).copy_(&qt);
 
-        /*for p in 0..l {
-            for r in 0..f.bases.len_of(Axis(1)) {
-                let _ = bases
-                    .i((idx as i64, p as i64, r as i64))
-                    .fill_(f.bases[[p, r]] as i64);
-
-                let _ = quals
-                    .i((idx as i64, p as i64, r as i64))
-                    .fill_(f.quals[[p, r]] as f64);
-            }
-        }*/
-
-        //println!("Bases shape: {:?}", f.bases.shape());
-        //println!("Quals shape: {:?}", f.quals.shape());
-
         lens.push(f.supported.len() as i32);
 
         let tidx: Vec<_> = f
@@ -154,33 +139,7 @@ fn collate<'a>(batch: &[(u32, &ConsensusWindow)]) -> InferenceBatch {
             .map(|&sp| (f.indices[sp.pos as usize] + sp.ins as usize) as i32)
             .collect();
         indices.push(Tensor::try_from(tidx).unwrap());
-
-        /*if *wid == 0 && f.rid == 133874 {
-            bases
-                .i((idx as i64, ..l as i64, ..))
-                .save("bases.pt")
-                .unwrap();
-
-            Tensor::try_from(&f.bases)
-                .unwrap()
-                .save("bases2.pt")
-                .unwrap();
-            /*quals
-            .i((idx as i64, ..l as i64, ..))
-            .save("quals.pt")
-            .unwrap();*/
-
-            //Tensor::try_from(&tidx).unwrap().save("indices.pt").unwrap();
-        }*/
     }
-
-    /*if batch[0].1.supported.contains(&SupportedPos::new(837, 0))
-        && batch[0].1.supported.contains(&SupportedPos::new(1157, 0))
-    {
-        bases.save("bases_to_test.tmp2.pt").unwrap();
-        quals.save("quals_to_test.tmp2.pt").unwrap();
-        indices[0].save("indices_to_test.tmp2.pt").unwrap();
-    }*/
 
     InferenceBatch::new(wids, bases, quals, Tensor::try_from(lens).unwrap(), indices)
 }
@@ -210,10 +169,7 @@ fn inference(
     };
 
     let info_logits = info_logits.to(tch::Device::Cpu).split_with_sizes(&lens, 0);
-    let bases_logits = bases_logits
-        //.argmax(1, false)
-        .to(tch::Device::Cpu)
-        .split_with_sizes(&lens, 0);
+    let bases_logits = bases_logits.to(tch::Device::Cpu).split_with_sizes(&lens, 0);
 
     (batch.wids, info_logits, bases_logits)
 }
@@ -251,13 +207,6 @@ pub(crate) fn inference_worker<P: AsRef<Path>>(
                 });
         }
 
-        /*println!(
-            "Device {}, in: {}, out: {}",
-            d,
-            input_channel.len(),
-            output_channel.len()
-        );*/
-
         output_channel.send(data.consensus_data).unwrap();
     }
 }
@@ -272,13 +221,8 @@ pub(crate) fn prepare_examples(
             // Transform bases (encode) and quals (normalize)
             example.bases.mapv_inplace(|b| BASES_MAP[b as usize]);
 
-            // Transpose: [R, L] -> [L, R]
-            //bases.swap_axes(1, 0);
-            //quals.swap_axes(1, 0);
-
             let tidx = get_target_indices(&example.bases);
 
-            //TODO: Start here.
             ConsensusWindow::new(
                 example.rid,
                 example.wid,

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -104,6 +104,7 @@ fn collate<'a>(batch: &[(u32, &ConsensusWindow)]) -> InferenceBatch {
         wids.push(*wid);
         let l = f.bases.len_of(Axis(0));
 
+        assert!(f.quals.is_standard_layout());
         let bt = unsafe {
             let shape: Vec<_> = f.bases.shape().iter().map(|s| *s as i64).collect();
             Tensor::from_blob(
@@ -115,6 +116,7 @@ fn collate<'a>(batch: &[(u32, &ConsensusWindow)]) -> InferenceBatch {
             )
         };
 
+        assert!(f.quals.is_standard_layout());
         let qt = unsafe {
             let shape: Vec<_> = f.quals.shape().iter().map(|s| *s as i64).collect();
             Tensor::from_blob(
@@ -152,6 +154,24 @@ fn collate<'a>(batch: &[(u32, &ConsensusWindow)]) -> InferenceBatch {
             .map(|&sp| (f.indices[sp.pos as usize] + sp.ins as usize) as i32)
             .collect();
         indices.push(Tensor::try_from(tidx).unwrap());
+
+        /*if *wid == 0 && f.rid == 133874 {
+            bases
+                .i((idx as i64, ..l as i64, ..))
+                .save("bases.pt")
+                .unwrap();
+
+            Tensor::try_from(&f.bases)
+                .unwrap()
+                .save("bases2.pt")
+                .unwrap();
+            /*quals
+            .i((idx as i64, ..l as i64, ..))
+            .save("quals.pt")
+            .unwrap();*/
+
+            //Tensor::try_from(&tidx).unwrap().save("indices.pt").unwrap();
+        }*/
     }
 
     /*if batch[0].1.supported.contains(&SupportedPos::new(837, 0))
@@ -191,7 +211,7 @@ fn inference(
 
     let info_logits = info_logits.to(tch::Device::Cpu).split_with_sizes(&lens, 0);
     let bases_logits = bases_logits
-        .argmax(1, false)
+        //.argmax(1, false)
         .to(tch::Device::Cpu)
         .split_with_sizes(&lens, 0);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -335,7 +335,7 @@ fn prepare_cuda_devices(devices: &[usize]) -> Vec<usize> {
             })
             .collect();
 
-        println!(
+        eprintln!(
             "Using CUDA_VISIBLE_DEVICES='{}'; mapped devices {:?} to logical IDs {:?}",
             cvd, devices, mapped
         );
@@ -349,7 +349,7 @@ fn prepare_cuda_devices(devices: &[usize]) -> Vec<usize> {
             .join(",");
         std::env::set_var("CUDA_VISIBLE_DEVICES", &device_list);
 
-        println!(
+        eprintln!(
             "Set CUDA_VISIBLE_DEVICES='{}' (for requested devices {:?})",
             device_list, devices
         );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,6 +125,8 @@ pub fn error_correction<T, U, V>(
     U: AsRef<Path> + Send + Sync,
     V: AsRef<Path> + Send,
 {
+    let devices = prepare_cuda_devices(&devices);
+
     tch::set_num_threads(1);
 
     let (core, neighbour) = read_cluster(&cluster_path);
@@ -312,4 +314,47 @@ fn write_sequence<W: Write>(
     write!(writer, "\n")?;
 
     Ok(())
+}
+
+fn prepare_cuda_devices(devices: &[usize]) -> Vec<usize> {
+    // Try to read CUDA_VISIBLE_DEVICES
+    if let Ok(cvd) = std::env::var("CUDA_VISIBLE_DEVICES") {
+        // CUDA_VISIBLE_DEVICES is set, map real device IDs to logical
+        let map: Vec<usize> = cvd
+            .split(',')
+            .filter_map(|s| s.trim().parse::<usize>().ok())
+            .collect();
+
+        // For each requested device, find its index in the mask
+        let mapped: Vec<usize> = devices
+            .iter()
+            .map(|dev| {
+                map.iter()
+                    .position(|&d| d == *dev)
+                    .unwrap_or_else(|| panic!("Device {} not in CUDA_VISIBLE_DEVICES={}", dev, cvd))
+            })
+            .collect();
+
+        println!(
+            "Using CUDA_VISIBLE_DEVICES='{}'; mapped devices {:?} to logical IDs {:?}",
+            cvd, devices, mapped
+        );
+        mapped
+    } else {
+        // Not set; set CUDA_VISIBLE_DEVICES to requested devices
+        let device_list = devices
+            .iter()
+            .map(|d| d.to_string())
+            .collect::<Vec<_>>()
+            .join(",");
+        std::env::set_var("CUDA_VISIBLE_DEVICES", &device_list);
+
+        println!(
+            "Set CUDA_VISIBLE_DEVICES='{}' (for requested devices {:?})",
+            device_list, devices
+        );
+
+        // Logical IDs match order of requested devices
+        (0..devices.len()).collect()
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -193,7 +193,8 @@ pub fn error_correction<T, U, V>(
                 )
             });
 
-            s.spawn(move || consensus_worker(cons_recv, writer_s));
+            let reads_ref = &reads;
+            s.spawn(move || consensus_worker(reads_ref, cons_recv, writer_s));
         }
 
         drop(writer_sender);

--- a/src/overlaps.rs
+++ b/src/overlaps.rs
@@ -369,7 +369,6 @@ pub(crate) fn alignment_reader<T: AsRef<Path>, U: AsRef<Path>>(
             .unwrap();
 
         alignments.into_iter().for_each(|example| {
-            //println!("Aln reader: {}", alns_sender.len());
             alns_sender.send(example).unwrap();
         });
     }


### PR DESCRIPTION
## Summary

- **Identity-based overlap sorting** — overlaps are now scored by a weighted identity metric (`matches/(matches+mismatches) * ln(n+1)`) computed across all supported positions before trimming to the top-30. 
- **Full logit output** — `bases_logits` now carries full `Vec<f32>` probability vectors instead of precomputed argmax indices, with argmax deferred to consensus time using `OrderedFloat`. This enables future use of logit confidence.
- **Dynamic support threshold** — the `get_supported` threshold is now 10% of the row count (dynamic) rather than a fixed count of 3, scaling correctly with coverage.
- **Indel filter loosened** — long-indel cutoff for overlap window filtering raised from `≥ 30` to `> 50` bp, retaining more alignments in indel-rich regions.
- **CUDA device mapping** — new `prepare_cuda_devices()` correctly maps requested device IDs against `CUDA_VISIBLE_DEVICES`, fixing multi-GPU setups where logical and physical IDs diverge.
- **libtorch 2.0 → 2.4 / tch 0.13 → 0.17** — updated throughout: `Cargo.toml`, `README.md`, `Dockerfile`, and `herro-singularity.def`. CUDA base image bumped from 11.7.1 to 12.4.1.
- **Dead code cleanup** — removed commented-out debug blocks, unused debug prints, and obsolete test stubs across `inference.rs`, `consensus.rs`, and `features.rs`.
- **Version** set to `0.1.1` consistently across all files.